### PR TITLE
[CI] blacksmith action to build docker image

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
 
-
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2204


### PR DESCRIPTION
resolves #81 

switch to blacksmith's docker build image that uses their cache to greatly increase CI speed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the container build process to improve deployment consistency and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->